### PR TITLE
Adsk contrib/vfx/5.6.1maya

### DIFF
--- a/qmake/generators/win32/winmakefile.cpp
+++ b/qmake/generators/win32/winmakefile.cpp
@@ -264,7 +264,7 @@ void Win32MakefileGenerator::processRcFileVar()
 
         QStringList vers = project->first("VERSION").toQString().split(".", QString::SkipEmptyParts);
         for (int i = vers.size(); i < 4; i++)
-            vers += "0";
+            vers += "2"; //it's "0" here for Maya2017, "1" for Update2, "2" for update3. "5.6.1.1"->"5.6.1.2"
         QString versionString = vers.join('.');
 
         QStringList rcIcons;

--- a/src/gui/util/qvalidator.cpp
+++ b/src/gui/util/qvalidator.cpp
@@ -641,6 +641,7 @@ QDoubleValidator::~QDoubleValidator()
 #   define LLONG_MAX Q_INT64_C(0x7fffffffffffffff)
 #endif
 
+#define ADSK_QDOUBLEVALIDATOR
 QValidator::State QDoubleValidator::validate(QString & input, int &) const
 {
     Q_D(const QDoubleValidator);
@@ -654,8 +655,15 @@ QValidator::State QDoubleValidator::validate(QString & input, int &) const
             numMode = QLocaleData::DoubleScientificMode;
             break;
     }
-
+#ifdef ADSK_QDOUBLEVALIDATOR
+    State currentLocaleValidation = d->validateWithLocale(input, numMode, locale());
+    if (currentLocaleValidation == Acceptable || locale().language() == QLocale::C)
+        return currentLocaleValidation;
+    State cLocaleValidation = d->validateWithLocale(input, numMode, QLocale(QLocale::C));
+    return qMax(currentLocaleValidation, cLocaleValidation);
+#else
     return d->validateWithLocale(input, numMode, locale());
+#endif
 }
 
 QValidator::State QDoubleValidatorPrivate::validateWithLocale(QString &input, QLocaleData::NumberMode numMode, const QLocale &locale) const

--- a/src/widgets/dialogs/qfileinfogatherer.cpp
+++ b/src/widgets/dialogs/qfileinfogatherer.cpp
@@ -220,7 +220,7 @@ void QFileInfoGatherer::run()
         getFileInfos(thisPath, thisList);
     }
 }
-
+#if defined(Q_OS_WIN)
 static QString mappedDriveType(const QFileInfoPrivate *fileInfo)
 {
     if (!fileInfo)
@@ -229,7 +229,7 @@ static QString mappedDriveType(const QFileInfoPrivate *fileInfo)
     return fileInfo->isConnected() ? QObject::tr("Network Drive")
                                    : QObject::tr("Disconnected Network Drive");
 }
-
+#endif
 QExtendedInformation QFileInfoGatherer::getInfo(const QFileInfo &fileInfo) const
 {
     QExtendedInformation info(fileInfo);


### PR DESCRIPTION
Include Qt4 QDoubleValidator to enable either local locale or C dot or comma delimiter。

To fix MAYA-72911. Patch Qt5.6.1 for Maya.