### PR TITLE
qDecodeDataUrl(): fix precondition violation in call to QByteArrayVie…

### DIFF
--- a/src/corelib/io/qdataurl.cpp
+++ b/src/corelib/io/qdataurl.cpp
@@ -47,10 +47,10 @@ Q_CORE_EXPORT bool qDecodeDataUrl(const QUrl &uri, QString &mimeType, QByteArray
         QLatin1StringView textPlain;
         constexpr auto charset = "charset"_L1;
         if (QLatin1StringView{data}.startsWith(charset, Qt::CaseInsensitive)) {
-            qsizetype i = charset.size();
-            while (data.at(i) == ' ')
-                ++i;
-            if (data.at(i) == '=')
+            QByteArrayView copy = data.sliced(charset.size());
+            while (copy.startsWith(' '))
+                copy.slice(1);
+            if (copy.startsWith('='))
                 textPlain = "text/plain;"_L1;
         }
 

--- a/tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp
+++ b/tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp
@@ -34,6 +34,8 @@ void tst_QDataUrl::decode_data()
         "text/plain"_L1, QByteArray::fromPercentEncoding("%E2%88%9A"));
     row("everythingIsCaseInsensitive", "Data:texT/PlaiN;charSet=iSo-8859-1;Base64,SGVsbG8=", true,
         "texT/PlaiN;charSet=iSo-8859-1"_L1, QByteArrayLiteral("Hello"));
+    row("prematureCharsetEnd", "data:charset,", true,
+        "charset", ""); // nonsense result, but don't crash
 }
 
 void tst_QDataUrl::decode()


### PR DESCRIPTION
It is a precondition violation to call QByteArrayView::at() with size() as argument. The code used that, though, as an implicit end-of-string check, assuming == ' ' and == '=' would both fail for null bytes. Besides, QByteArrays (but most certainly QByteArrayViews) need not be null-terminated, so this could read even past size().

To fix, use higher-level API (startsWith()), consuming parsed tokens along the way.

Add a test that would crash in debug mode before the fix.

Amends the start of the public history.

[ChangeLog][QtCore] Fixed a bug in the handling of data: URLs that could lead to a crash if Qt was built with assertions enabled. This affects QNetworkManager and links in QTextDocument.

Fixes: CVE-2025-5455
(cherry picked from commit 4d839093b480d30eef8a89c0f864ee3f340adaa1)